### PR TITLE
Add points per minute logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.prettierignore


### PR DESCRIPTION
# Dominion Timer Extension: Points Per Minute & Improved Final Message Formatting

## Summary
This PR adds **points per minute** calculation to the final timer message and improves formatting for clarity.

- **Points are now polled during the game** and reliably included at game end.
- The final timer message uses enumerated player lines:
```

(1) Player took 1:23 (12.34 points/minute); (2) Player took ...

````
- The message is inserted into the chat input, ready for sharing.

---

## Key Changes

1. **Consistent Time & Points Calculation**
 - Uses `getMinutesAndSeconds(ms)` for all time and points calculations, ensuring display and math match.
 - Points are polled from the in-game UI and stored in `dataByPlayer[player].points`.

2. **Improved Final Timer Message Formatting**
 - Each player’s result is enumerated for clarity:
   ```
   (1) Alice took 1:23 (12.34 points/minute); (2) Bob took ...
   ```
 - Uses `;` as a separator for single-line chat input compatibility.

3. **Reliable Points Capture**
 - `observerPlayerPoints()` is called at the beginning of the game and uses `MutationObserver` to update points when the relevant DOM node changes.

---

## Example Output
````

(1) Alice took 1:23 (12.34 points/minute); (2) Bob took 2:05 (9.57 points/minute); (3) Carol took 0:58 (15.52 points/minute);
````
---

## How to Test
1. Play a game on [dominion.games](https://dominion.games) with the extension enabled.
2. At game end, check the chat input for the formatted timer message with points per minute for each player.
3. Confirm the message is clear, accurate, and ready to share.